### PR TITLE
fix: remove compile warning related to environment variable mismatch during build and runtime

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -22,6 +22,14 @@ config :flick, FlickWeb.Endpoint,
   pubsub_server: Flick.PubSub,
   live_view: [signing_salt: "D3iFdkff"]
 
+# We do basic auth for the admin index in production.
+#
+# During a deployment build, we expect these environment variables to be set,
+# otherwise we'll put in some defaults.
+config :flick, :basic_auth,
+  username: System.get_env("BASIC_AUTH_ADMIN_USERNAME", "flick-admin"),
+  password: System.get_env("BASIC_AUTH_ADMIN_PASSWORD", "unsafe-password")
+
 # Configures the mailer
 #
 # By default it uses the "Local" adapter which stores the emails

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -29,9 +29,6 @@ config :flick, FlickWeb.Endpoint,
     tailwind: {Tailwind, :install_and_run, [:flick, ~w(--watch)]}
   ]
 
-# Basic HTTP authentication for the `/admin` pages.
-config :flick, :basic_auth, username: "flick-admin", password: "unsafe-password"
-
 # ## SSL Support
 #
 # In order to use HTTPS in development, a self-signed

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -70,9 +70,21 @@ if config_env() == :prod do
     secret_key_base: secret_key_base
 
   # We do basic auth for the admin index in production.
+  basic_auth_username =
+    System.get_env("BASIC_AUTH_ADMIN_USERNAME") ||
+      raise """
+      Environment variable SECRET_KEY_BASE is missing.
+      """
+
+  basic_auth_password =
+    System.get_env("BASIC_AUTH_ADMIN_PASSWORD") ||
+      raise """
+      Environment variable BASIC_AUTH_ADMIN_PASSWORD is missing.
+      """
+
   config :flick, :basic_auth,
-    username: System.get_env("BASIC_AUTH_ADMIN_USERNAME"),
-    password: System.get_env("BASIC_AUTH_ADMIN_PASSWORD")
+    username: basic_auth_username,
+    password: basic_auth_password
 
   # ## SSL Support
   #

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -73,7 +73,7 @@ if config_env() == :prod do
   basic_auth_username =
     System.get_env("BASIC_AUTH_ADMIN_USERNAME") ||
       raise """
-      Environment variable SECRET_KEY_BASE is missing.
+      Environment variable BASIC_AUTH_ADMIN_USERNAME is missing.
       """
 
   basic_auth_password =

--- a/config/test.exs
+++ b/config/test.exs
@@ -31,6 +31,3 @@ config :logger, level: :warning
 
 # Initialize plugs at runtime for faster test compilation
 config :phoenix, :plug_init_mode, :runtime
-
-# Basic HTTP authentication for the `/admin` pages.
-config :flick, :basic_auth, username: "flick-admin", password: "unsafe-password"

--- a/lib/flick_web/router.ex
+++ b/lib/flick_web/router.ex
@@ -13,9 +13,7 @@ defmodule FlickWeb.Router do
   end
 
   pipeline :admin do
-    # The use of `get_env/2` is temp.
-    # https://github.com/zorn/flick/issues/56
-    plug :basic_auth, Application.get_env(:flick, :basic_auth)
+    plug :basic_auth, Application.compile_env(:flick, :basic_auth)
   end
 
   pipeline :api do


### PR DESCRIPTION
Fixes #56

Update how we configure `:basic_auth`, ensuring we look for environment variables during compile time, allowing them to match the runtime configuration and thus making `Application.compile_env/3` happy.