### PR TITLE
chore: downgrade Erlang for deployment

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 27.1.1
+erlang 27.0.1
 elixir 1.17.3-otp-27


### PR DESCRIPTION
Currently Render did not support `27.1.1`.

https://docs.render.com/elixir-erlang-versions