### PR TITLE
feat: add uptime link to footer

### DIFF
--- a/lib/flick_web/components/layouts/app.html.heex
+++ b/lib/flick_web/components/layouts/app.html.heex
@@ -34,6 +34,7 @@
     <a href="https://github.com/zorn/flick" class="underline">
       GitHub Project
     </a>
+    &bull; <a href="https://updown.io/wwis">Uptime</a>
     &bull; <a href="mailto:mike@mikezornek.com" class="underline">Contact Site Admin</a>
   </FlickWeb.UI.page_column>
 </section>


### PR DESCRIPTION
Fixes: #122

This service verifies the site's uptime. 

Figured, why not just make it public to help add confidence?

https://updown.io/wwis