### PR TITLE
fix: update content security policy for plausible

### DIFF
--- a/lib/flick_web/components/layouts/root.html.heex
+++ b/lib/flick_web/components/layouts/root.html.heex
@@ -13,11 +13,8 @@
     <script
       defer
       data-domain="rankedvote.app"
-      src="https://plausible.io/js/script.file-downloads.hash.outbound-links.pageview-props.revenue.tagged-events.js"
+      src="https://plausible.io/js/script.hash.pageview-props.revenue.tagged-events.js"
     >
-    </script>
-    <script>
-      window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }
     </script>
   </head>
   <body class="bg-white antialiased flick-web">

--- a/lib/flick_web/router.ex
+++ b/lib/flick_web/router.ex
@@ -21,7 +21,7 @@ defmodule FlickWeb.Router do
     # might be reconsidered.
     plug :put_secure_browser_headers, %{
       "content-security-policy" =>
-        "default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'"
+        "default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self' https://plausible.io; connect-src 'self' https://plausible.io"
     }
   end
 


### PR DESCRIPTION
Fixes #135 

Update the content security policy to include Plausible domain.

Reduce the Plausible configuration and inline `<script>` tag, since solving for that is more painful than I am interested in.