### PR TITLE
ci: update sobelow config to better report failures in ci

### DIFF
--- a/.sobelow-conf
+++ b/.sobelow-conf
@@ -1,1 +1,1 @@
-[verbose: true, private: false, skip: false, router: nil, exit: false, format: "txt", out: nil, threshold: :low, ignore: ["Config.HTTPS"], ignore_files: [], version: false]
+[verbose: true, private: false, skip: false, router: nil, exit: "Low", format: "txt", out: nil, threshold: :low, ignore: ["Config.HTTPS"], ignore_files: [], version: false]

--- a/lib/flick_web/router.ex
+++ b/lib/flick_web/router.ex
@@ -19,10 +19,10 @@ defmodule FlickWeb.Router do
     # To avoid web console issues with Phoenix Storybook we've added
     # `style-src 'self' 'unsafe-inline'` which feels unfortunate and
     # might be reconsidered.
-    plug :put_secure_browser_headers, %{
-      "content-security-policy" =>
-        "default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self' https://plausible.io; connect-src 'self' https://plausible.io"
-    }
+    # plug :put_secure_browser_headers, %{
+    #   "content-security-policy" =>
+    #     "default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self' https://plausible.io; connect-src 'self' https://plausible.io"
+    # }
   end
 
   pipeline :admin do

--- a/lib/flick_web/router.ex
+++ b/lib/flick_web/router.ex
@@ -19,10 +19,10 @@ defmodule FlickWeb.Router do
     # To avoid web console issues with Phoenix Storybook we've added
     # `style-src 'self' 'unsafe-inline'` which feels unfortunate and
     # might be reconsidered.
-    # plug :put_secure_browser_headers, %{
-    #   "content-security-policy" =>
-    #     "default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self' https://plausible.io; connect-src 'self' https://plausible.io"
-    # }
+    plug :put_secure_browser_headers, %{
+      "content-security-policy" =>
+        "default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self' https://plausible.io; connect-src 'self' https://plausible.io"
+    }
   end
 
   pipeline :admin do


### PR DESCRIPTION
Related to [this social post](https://fosstodon.org/@tylerayoung/115022172773272548) from @s3cur3, this work updates and demonstrates the need to configure `sobelow` with `exit: "Low"` to make sure failure results in a non-zero exit status, and thus show up as failed inside of continuous integration.