### PR TITLE
feat: adds a local development only Docker Compose file with Postgres 17 (needed for local development) [render skip]

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,8 @@
     "cSpell.words": [
         "Appsignal",
         "Ecto",
+        "healthcheck",
+        "isready",
         "rankedvote",
         "Struct",
         "Structs",

--- a/README.md
+++ b/README.md
@@ -33,7 +33,33 @@ YouTube: <https://www.youtube.com/watch?v=pxE6AbaQuUM>
 
 ![Ballot Admin page](docs/screenshots/admin-page.png)
 
-## Standard Phoenix Readme
+## Running in Local Development
+
+### Install Elixir via `asdf`
+
+This project is built using Elixir and Erlang, and as such we define specific version targets using `.tool-versions` a file format of the [asdf project](https://asdf-vm.com/). Please refer to it for [various installation options](https://asdf-vm.com/guide/getting-started.html). Once installed, run the following from the project root to make sure you have the required versions.
+
+```bash
+$ asdf install
+```
+
+### Start Postgres
+
+This project requires a Postgres database for storage and a Docker Compose file to run a containerized version is provided via `compose.yml`. You are not required to run Postgres via a container, and a standard on metal installation should work fine too.
+
+Before attempting to run the Phoenix app, be sure to start the Docker container with:
+
+```bash
+$ docker compose up -d
+```
+
+To shutdown you can run:
+
+```bash
+$ docker compose down -d
+```
+
+### Start Phoenix
 
 To start your Phoenix server:
 

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,34 @@
+# This Docker Compose file is intended for local development and does not impact
+# any production environments.
+#
+# From the root of the project run:
+#
+# $ docker compose up -d
+#
+# $ docker compose down -d
+#
+# FUTURE ENHANCEMENTS IDEAS:
+# - We could consider using a `https://hub.docker.com/r/postgis/postgis/`
+#   version of the database image to better align with what will be seen in
+#   production on Render.
+
+services:
+  db:
+    image: postgres:17
+    healthcheck:
+      test: ["CMD", "pg_isready", "--username=postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    deploy:
+      restart_policy:
+        condition: on-failure
+    environment:
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - "${POSTGRES_PORT:-5432}:5432"
+    volumes:
+      - db_data:/var/lib/postgresql/data
+
+volumes:
+  db_data:

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -68,7 +68,7 @@ end
 SeedScripts.populate_ballot_with_votes(sandwich_ballot_published)
 
 # Create a draft ballot.
-{:ok, color_ballot} =
+{:ok, _color_ballot} =
   Flick.RankedVoting.create_ballot(%{
     question_title: "What is your favorite color?",
     possible_answers: "Red, Green, Blue",
@@ -85,4 +85,4 @@ SeedScripts.populate_ballot_with_votes(sandwich_ballot_published)
 
 {:ok, fruit_ballot_published} = Flick.RankedVoting.publish_ballot(fruit_ballot)
 SeedScripts.populate_ballot_with_votes(fruit_ballot_published)
-{:ok, fruit_ballot_closed} = Flick.RankedVoting.close_ballot(fruit_ballot_published)
+{:ok, _fruit_ballot_closed} = Flick.RankedVoting.close_ballot(fruit_ballot_published)

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -56,6 +56,11 @@ defmodule SeedScripts do
   end
 end
 
+# An assertion of expectations that we have no ballots in the database when we start.
+if [] != Flick.RankedVoting.list_ballots() do
+  raise "We expect no ballots in the database when running seed scripts, but saw #{length(Flick.RankedVoting.list_ballots())} ballot(s)."
+end
+
 # Create a published ballot with some votes.
 {:ok, sandwich_ballot} =
   Flick.RankedVoting.create_ballot(%{


### PR DESCRIPTION
Fixes #158

As noted in the Docker Compose file's comments -- this `compose.yml` is only intended to help run the project in a local developer environment. Real production infrastructure is defined in the `render.yml` file.

Adding `[render skip]` since this does not need to be deployed when merged into `main`.