### PR TITLE
chore: updates to Postgres 18 for local dev compose, test runner and production blueprint

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -26,7 +26,7 @@ jobs:
 
     services:
       db:
-        image: postgres:17
+        image: postgres:18
         ports: ["5432:5432"]
         env:
           POSTGRES_USER: postgres

--- a/compose.yml
+++ b/compose.yml
@@ -14,9 +14,12 @@
 
 services:
   db:
-    image: postgres:17
+    image: postgres:18
     healthcheck:
-      test: ["CMD", "pg_isready", "--username=postgres"]
+      test:
+        - "CMD"
+        - "pg_isready"
+        - "--username=postgres"
       interval: 10s
       timeout: 5s
       retries: 5

--- a/render.yaml
+++ b/render.yaml
@@ -8,6 +8,7 @@ databases:
   ipAllowList:
   - source: 0.0.0.0/0
     description: everywhere
+  # NOTE: Updating postgresMajorVersion here does not upgrade an existing Render database in-place; use Render's manual/in-place upgrade tooling.
   postgresMajorVersion: "18"
   diskSizeGB: 1
 services:

--- a/render.yaml
+++ b/render.yaml
@@ -8,7 +8,7 @@ databases:
   ipAllowList:
   - source: 0.0.0.0/0
     description: everywhere
-  postgresMajorVersion: "17"
+  postgresMajorVersion: "18"
   diskSizeGB: 1
 services:
 - type: web


### PR DESCRIPTION
The production blueprint change does not apply on deploy. You still need to run the manual upgrade in place Render tool, which I am doing alongside this PR.