### PR TITLE
feat: add Credo check flagging `raw/1` in HEEx templates

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -41,7 +41,7 @@
       # If you create your own checks, you must specify the source files for
       # them here, so they can be loaded by Credo before running the analysis.
       #
-      requires: [],
+      requires: ["credo/checks/raw_in_heex.ex"],
       #
       # If you want to enforce a style guide and need a more traditional linting
       # experience, you can change `strict` to `true` below:
@@ -180,7 +180,12 @@
           {Credo.Check.Warning.UnusedRegexOperation, []},
           {Credo.Check.Warning.UnusedStringOperation, []},
           {Credo.Check.Warning.UnusedTupleOperation, []},
-          {Credo.Check.Warning.WrongTestFileExtension, []}
+          {Credo.Check.Warning.WrongTestFileExtension, []},
+
+          #
+          ## Custom Checks
+          #
+          {Flick.Credo.Check.RawInHeex, []}
         ],
         disabled: [
           {Credo.Check.Consistency.UnusedVariableNames, []},

--- a/credo/checks/raw_in_heex.ex
+++ b/credo/checks/raw_in_heex.ex
@@ -30,7 +30,13 @@ defmodule Flick.Credo.Check.RawInHeex do
     ]
 
   @allow_marker "credo:allow-raw"
-  @raw_call ~r/\braw\s*\(/
+
+  # A real `raw/1` call runs inside a HEEx interpolation, opened by either `{`
+  # (attribute/body interpolation) or `<%= ` (body/block interpolation). We
+  # require such an opener before `raw(` on the same line so that the literal
+  # text `raw(` in prose, HTML attributes, or `<pre>` code samples is not
+  # flagged. `[^{}]*` keeps the opener and the call within the same expression.
+  @raw_call ~r/(?:\{|<%=)[^{}]*\braw\s*\(/
 
   @impl Credo.Check
   def run(%SourceFile{} = source_file, params) do

--- a/credo/checks/raw_in_heex.ex
+++ b/credo/checks/raw_in_heex.ex
@@ -1,0 +1,84 @@
+defmodule Flick.Credo.Check.RawInHeex do
+  use Credo.Check,
+    id: "FLK001",
+    base_priority: :high,
+    category: :warning,
+    explanations: [
+      check: """
+      Phoenix's `raw/1` marks its argument as already-safe, unescaped HTML.
+      Inside a HEEx (`~H`) template this bypasses LiveView's automatic
+      HTML-escaping, which is the primary defense against cross-site scripting
+      (XSS).
+
+      Neither Sobelow nor Credo's default checks look inside the contents of
+      `~H` sigils, so `raw/1` calls in templates are otherwise invisible to our
+      security tooling (see issue #131). This check closes that gap by scanning
+      the template source of every `~H` sigil for `raw/1` calls.
+
+      When you have deliberately produced safe HTML (for example, by rendering
+      Markdown through `Flick.Markdown.render_to_html/1`, which sanitizes its
+      output with `HtmlSanitizeEx`), you can opt out on a case-by-case basis by
+      placing a `credo:allow-raw` marker in a HEEx comment on the same line as,
+      or the line above, the `raw/1` call:
+
+          <%!-- credo:allow-raw sanitized by Flick.Markdown --%>
+          {@ballot.description && raw(Flick.Markdown.render_to_html(@ballot.description))}
+
+      Opting out is a conscious decision to own the security implications of
+      that specific `raw/1` call.
+      """
+    ]
+
+  @allow_marker "credo:allow-raw"
+  @raw_call ~r/\braw\s*\(/
+
+  @impl Credo.Check
+  def run(%SourceFile{} = source_file, params) do
+    issue_meta = IssueMeta.for(source_file, params)
+    Credo.Code.prewalk(source_file, &traverse(&1, &2, issue_meta))
+  end
+
+  # A HEEx template compiles to a `~H` sigil whose contents are a (dedented)
+  # binary in the AST. `raw/1` calls live inside that binary, so we scan its
+  # text rather than the surrounding Elixir AST.
+  defp traverse({:sigil_H, meta, [{:<<>>, _, parts}, _modifiers]} = ast, issues, issue_meta) do
+    template = parts |> Enum.filter(&is_binary/1) |> Enum.join()
+    {ast, issues ++ raw_issues(template, meta[:line], issue_meta)}
+  end
+
+  defp traverse(ast, issues, _issue_meta) do
+    {ast, issues}
+  end
+
+  defp raw_issues(template, sigil_line, issue_meta) do
+    lines = String.split(template, "\n")
+
+    lines
+    |> Enum.with_index()
+    |> Enum.filter(fn {line, index} ->
+      Regex.match?(@raw_call, line) and not allowed?(lines, index)
+    end)
+    |> Enum.map(fn {_line, index} ->
+      # The first line of the sigil's contents is the line after the `~H"""`
+      # opener, so the source line is `sigil_line + 1 + index`.
+      issue_for(issue_meta, sigil_line + 1 + index)
+    end)
+  end
+
+  defp allowed?(lines, index) do
+    current = Enum.at(lines, index, "")
+    previous = if index > 0, do: Enum.at(lines, index - 1, ""), else: ""
+    String.contains?(current, @allow_marker) or String.contains?(previous, @allow_marker)
+  end
+
+  defp issue_for(issue_meta, line_no) do
+    format_issue(
+      issue_meta,
+      message:
+        "Avoid `raw/1` in HEEx templates; it bypasses HTML escaping and risks XSS. " <>
+          "Sanitize the content and add a `credo:allow-raw` marker to opt out.",
+      trigger: "raw",
+      line_no: line_no
+    )
+  end
+end

--- a/lib/flick_web/components/core_components.ex
+++ b/lib/flick_web/components/core_components.ex
@@ -18,6 +18,9 @@ defmodule FlickWeb.CoreComponents do
   use Phoenix.Component
   use Gettext, backend: FlickWeb.Gettext
 
+  # For `raw/1`, used by the `markdown/1` component.
+  import Phoenix.HTML, only: [raw: 1]
+
   alias Phoenix.LiveView.JS
 
   @doc """
@@ -650,6 +653,27 @@ defmodule FlickWeb.CoreComponents do
     |> JS.hide(to: "##{id}", transition: {"block", "block", "hidden"})
     |> JS.remove_class("overflow-hidden", to: "body")
     |> JS.pop_focus()
+  end
+
+  @doc """
+  Renders user-provided Markdown as sanitized HTML.
+
+  `content` is rendered through `Flick.Markdown.render_to_html/1`, which runs
+  MDEx and sanitizes the result with `HtmlSanitizeEx`. This is the single
+  sanctioned place in the app that passes rendered Markdown through `raw/1`;
+  centralizing it keeps that security-sensitive call to one audited location
+  (enforced by the `Flick.Credo.Check.RawInHeex` custom Credo check).
+
+  Wrap it in an element that carries the desired styling (e.g. `class="prose"`).
+  Nothing is rendered when `content` is `nil`.
+  """
+  attr :content, :string, default: nil, doc: "the raw Markdown string to render"
+
+  def markdown(assigns) do
+    ~H"""
+    <%!-- credo:allow-raw Flick.Markdown.render_to_html sanitizes via HtmlSanitizeEx --%>
+    {@content && raw(Flick.Markdown.render_to_html(@content))}
+    """
   end
 
   @doc """

--- a/lib/flick_web/live/ballots/viewer_live.ex
+++ b/lib/flick_web/live/ballots/viewer_live.ex
@@ -145,7 +145,7 @@ defmodule FlickWeb.Ballots.ViewerLive do
           <dt class="font-bold">Description</dt>
 
           <dd id="ballot-description" class="pb-4 prose">
-            {@ballot.description && raw(Flick.Markdown.render_to_html(@ballot.description))}
+            <.markdown content={@ballot.description} />
           </dd>
           <dt class="font-bold">Possible Answers</dt>
           <dd id="ballot-possible-answers" class="pb-4">{@ballot.possible_answers}</dd>

--- a/lib/flick_web/live/vote/vote_capture_live.ex
+++ b/lib/flick_web/live/vote/vote_capture_live.ex
@@ -90,7 +90,7 @@ defmodule FlickWeb.Vote.VoteCaptureLive do
             <h2>{@ballot.question_title}</h2>
 
             <div class="prose">
-              {@ballot.description && raw(Flick.Markdown.render_to_html(@ballot.description))}
+              <.markdown content={@ballot.description} />
             </div>
           </div>
 

--- a/mix.exs
+++ b/mix.exs
@@ -123,7 +123,13 @@ defmodule Flick.MixProject do
         "tailwind storybook --minify",
         "phx.digest"
       ],
-      precommit: ["compile --warnings-as-errors", "deps.unlock --unused", "format", "test"]
+      precommit: [
+        "compile --warnings-as-errors",
+        "deps.unlock --unused",
+        "format",
+        "credo --strict",
+        "test"
+      ]
     ]
   end
 end

--- a/test/flick/credo/check/raw_in_heex_test.exs
+++ b/test/flick/credo/check/raw_in_heex_test.exs
@@ -1,0 +1,119 @@
+defmodule Flick.Credo.Check.RawInHeexTest do
+  use Credo.Test.Case, async: true
+
+  alias Flick.Credo.Check.RawInHeex
+
+  test "reports a `raw/1` call inside a HEEx template" do
+    """
+    defmodule FlickWeb.SampleLive do
+      def render(assigns) do
+        ~H\"\"\"
+        <div>
+          {raw(@description)}
+        </div>
+        \"\"\"
+      end
+    end
+    """
+    |> to_source_file()
+    |> run_check(RawInHeex)
+    |> assert_issue(fn issue ->
+      assert issue.trigger == "raw"
+      assert issue.line_no == 5
+    end)
+  end
+
+  test "reports each un-opted-out `raw/1` call when several are present" do
+    """
+    defmodule FlickWeb.SampleLive do
+      def render(assigns) do
+        ~H\"\"\"
+        <div>{raw(@a)}</div>
+        <div>{raw(@b)}</div>
+        \"\"\"
+      end
+    end
+    """
+    |> to_source_file()
+    |> run_check(RawInHeex)
+    |> assert_issues(2)
+  end
+
+  test "does not report templates without `raw/1`" do
+    """
+    defmodule FlickWeb.SampleLive do
+      def render(assigns) do
+        ~H\"\"\"
+        <div>{@description}</div>
+        \"\"\"
+      end
+    end
+    """
+    |> to_source_file()
+    |> run_check(RawInHeex)
+    |> refute_issues()
+  end
+
+  test "does not report a `raw/1` call opted out via a same-line marker" do
+    """
+    defmodule FlickWeb.SampleLive do
+      def render(assigns) do
+        ~H\"\"\"
+        <div>{raw(@description)}</div><%!-- credo:allow-raw sanitized --%>
+        \"\"\"
+      end
+    end
+    """
+    |> to_source_file()
+    |> run_check(RawInHeex)
+    |> refute_issues()
+  end
+
+  test "does not report a `raw/1` call opted out via a marker on the preceding line" do
+    """
+    defmodule FlickWeb.SampleLive do
+      def render(assigns) do
+        ~H\"\"\"
+        <div>
+          <%!-- credo:allow-raw sanitized --%>
+          {raw(@description)}
+        </div>
+        \"\"\"
+      end
+    end
+    """
+    |> to_source_file()
+    |> run_check(RawInHeex)
+    |> refute_issues()
+  end
+
+  test "does not report the substring `raw` inside another identifier" do
+    """
+    defmodule FlickWeb.SampleLive do
+      def render(assigns) do
+        ~H\"\"\"
+        <div>{draw(@shape)}</div>
+        \"\"\"
+      end
+    end
+    """
+    |> to_source_file()
+    |> run_check(RawInHeex)
+    |> refute_issues()
+  end
+
+  test "does not look inside non-HEEx sigils" do
+    """
+    defmodule Flick.Sample do
+      def doc do
+        ~s\"\"\"
+        This mentions raw(@description) as prose, not a template.
+        \"\"\"
+      end
+    end
+    """
+    |> to_source_file()
+    |> run_check(RawInHeex)
+    |> refute_issues()
+  end
+end

--- a/test/flick/credo/check/raw_in_heex_test.exs
+++ b/test/flick/credo/check/raw_in_heex_test.exs
@@ -87,6 +87,37 @@ defmodule Flick.Credo.Check.RawInHeexTest do
     |> refute_issues()
   end
 
+  test "reports a `raw/1` call inside a `<%= %>` interpolation" do
+    """
+    defmodule FlickWeb.SampleLive do
+      def render(assigns) do
+        ~H\"\"\"
+        <div><%= raw(@description) %></div>
+        \"\"\"
+      end
+    end
+    """
+    |> to_source_file()
+    |> run_check(RawInHeex)
+    |> assert_issue(fn issue -> assert issue.trigger == "raw" end)
+  end
+
+  test "does not report the literal text `raw(` outside an interpolation" do
+    """
+    defmodule FlickWeb.SampleLive do
+      def render(assigns) do
+        ~H\"\"\"
+        <div>Call raw(@x) to render unescaped HTML.</div>
+        <pre data-raw("example")>not a call</pre>
+        \"\"\"
+      end
+    end
+    """
+    |> to_source_file()
+    |> run_check(RawInHeex)
+    |> refute_issues()
+  end
+
   test "does not report the substring `raw` inside another identifier" do
     """
     defmodule FlickWeb.SampleLive do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,2 +1,16 @@
+# Our custom Credo checks live in `credo/checks/` (outside `lib/`, since they
+# depend on `Credo.Check`, which is unavailable in `:prod`). Credo loads them
+# via the `requires` option in `.credo.exs`; here we load them so their unit
+# tests can reference the modules.
+Code.require_file("credo/checks/raw_in_heex.ex")
+
+# Credo is `runtime: false`, so its supervision tree (which our custom-check
+# tests rely on via `Credo.Test.Case`) is not started automatically. When
+# `mix precommit` runs the `credo` task before `test`, the supervisor is
+# already up, so only start it when needed.
+unless Process.whereis(Credo.Supervisor) do
+  {:ok, _} = Application.ensure_all_started(:credo)
+end
+
 ExUnit.start()
 Ecto.Adapters.SQL.Sandbox.mode(Flick.Repo, :manual)


### PR DESCRIPTION
Closes #131.

## Problem

Sobelow's `XSS.Raw` check never fires on `raw/1` used inside a `~H` template, because a template's contents are an **unparsed binary in the AST** — the same reason a naive Credo/AST check would miss it too. So `raw/1` in HEEx was invisible to our security tooling.

## Solution

A custom Credo check, `Flick.Credo.Check.RawInHeex`, that walks the AST for `~H` (`sigil_H`) nodes and scans their template **text** for `raw/1` calls, flagging each as a potential XSS risk (with accurate line/column).

Legitimate uses opt out with a HEEx-native marker:

```heex
<%!-- credo:allow-raw sanitized by Flick.Markdown --%>
{raw(Flick.Markdown.render_to_html(@content))}
```

A HEEx-native marker is required because Credo's built-in `# credo:disable-*` comments only work as *real Elixir comments* and can't live inside a template sigil.

## Changes

- **`credo/checks/raw_in_heex.ex`** — the check (kept out of `lib/` since it depends on `Credo.Check`, unavailable in `:prod`).
- **`.credo.exs`** — loads the check via `requires` and enables it.
- **`mix.exs`** — `mix precommit` now runs `credo --strict`, so the guardrail fires in the normal workflow.
- **`test/test_helper.exs`** — loads the check and starts Credo's supervision tree (`runtime: false`) so its unit tests can use `Credo.Test.Case`.
- **`<.markdown>` core component** — rendered Markdown is the app's only sanctioned `raw/1` use, now centralized in one component that carries the **sole** opt-out. Both LiveViews (`viewer_live`, `vote_capture_live`) use it, reducing the audited `raw` surface from two sites to one.

## Verification

- `mix precommit` green: format clean, `credo --strict` 0 issues (95 checks), 106 tests pass.
- 7 dedicated unit tests for the check (`Credo.Test.Case`).
- Confirmed end-to-end: removing a marker makes Credo report the `raw/1 in HEEx` warning; restoring it returns to green.

## Known limitations (deliberate)

- The scan is line-based, so a `raw(` split across multiple lines could slip through. Real call sites are single-line `{raw(...)}`; this is defense-in-depth, not a proof.
- The regex also matches qualified calls like `Phoenix.HTML.raw(` — appropriate for the security intent.