### PR TITLE
fix: allow Plausible inline init script via CSP nonce

### DIFF
--- a/.sobelow-conf
+++ b/.sobelow-conf
@@ -1,1 +1,1 @@
-[verbose: true, private: false, skip: false, router: nil, exit: "Low", format: "txt", out: nil, threshold: :low, ignore: ["Config.HTTPS", "Config.CSP"], ignore_files: [], version: false]
+[verbose: true, private: false, skip: false, router: nil, exit: "Low", format: "txt", out: nil, threshold: :low, ignore: ["Config.HTTPS"], ignore_files: [], version: false]

--- a/.sobelow-conf
+++ b/.sobelow-conf
@@ -1,1 +1,1 @@
-[verbose: true, private: false, skip: false, router: nil, exit: "Low", format: "txt", out: nil, threshold: :low, ignore: ["Config.HTTPS"], ignore_files: [], version: false]
+[verbose: true, private: false, skip: false, router: nil, exit: "Low", format: "txt", out: nil, threshold: :low, ignore: ["Config.HTTPS", "Config.CSP"], ignore_files: [], version: false]

--- a/lib/flick_web/components/layouts/root.html.heex
+++ b/lib/flick_web/components/layouts/root.html.heex
@@ -14,7 +14,7 @@
     <!-- Privacy-friendly analytics by Plausible -->
     <script async src="https://plausible.io/js/pa-9IEM5uoRIpI0OwkV4Qqkv.js">
     </script>
-    <script nonce={assigns[:csp_nonce]}>
+    <script nonce={@csp_nonce}>
       window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
       plausible.init()
     </script>

--- a/lib/flick_web/components/layouts/root.html.heex
+++ b/lib/flick_web/components/layouts/root.html.heex
@@ -14,7 +14,7 @@
     <!-- Privacy-friendly analytics by Plausible -->
     <script async src="https://plausible.io/js/pa-9IEM5uoRIpI0OwkV4Qqkv.js">
     </script>
-    <script>
+    <script nonce={assigns[:csp_nonce]}>
       window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
       plausible.init()
     </script>

--- a/lib/flick_web/router.ex
+++ b/lib/flick_web/router.ex
@@ -5,10 +5,6 @@ defmodule FlickWeb.Router do
   import PhoenixStorybook.Router
   import Plug.BasicAuth
 
-  # Note: Sobelow's `Config.CSP` check only recognizes a CSP passed as a static
-  # map to `put_secure_browser_headers`. We set the header dynamically in
-  # `put_csp_headers` below (to inject a per-request nonce), so `Config.CSP` is
-  # ignored in `.sobelow-conf`.
   pipeline :browser do
     plug :accepts, ["html"]
     plug :fetch_session
@@ -16,8 +12,26 @@ defmodule FlickWeb.Router do
     plug :put_root_layout, html: {FlickWeb.Layouts, :root}
     plug :protect_from_forgery
 
-    plug :put_secure_browser_headers
-    plug :put_csp_headers
+    # Our Content Security Policy. Notes:
+    #
+    # - `img-src` allows `data:` URLs because Tailwind uses SVG data URLs for
+    #   icons.
+    # - `style-src` allows `'unsafe-inline'` to avoid web console issues with
+    #   Phoenix Storybook.
+    #
+    # `put_csp_nonce` below augments this static policy with a per-request nonce
+    # so the inline Plausible analytics `<script>` in the root layout is allowed
+    # without opening `script-src` up to `'unsafe-inline'`. We keep the full
+    # policy here (rather than building it entirely in the plug) so Sobelow's
+    # `Config.CSP` check can still verify a CSP is present.
+    #
+    # https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
+    plug :put_secure_browser_headers, %{
+      "content-security-policy" =>
+        "default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self' https://plausible.io; connect-src 'self' https://plausible.io"
+    }
+
+    plug :put_csp_nonce
   end
 
   pipeline :admin do
@@ -28,31 +42,17 @@ defmodule FlickWeb.Router do
     plug :accepts, ["json"]
   end
 
-  # Sets our Content Security Policy header.
-  #
-  # We generate a per-request `nonce` so the small inline Plausible analytics
-  # `<script>` in the root layout is allowed without opening up `script-src` to
-  # `'unsafe-inline'`. The nonce is assigned to the conn so the layout can stamp
-  # it onto that script tag.
-  #
-  # `style-src` allows `'unsafe-inline'` to avoid web console issues with
-  # Phoenix Storybook, and `img-src` allows `data:` URLs because Tailwind uses
-  # SVG data URLs for icons.
-  #
-  # https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
-  defp put_csp_headers(conn, _opts) do
+  # Generates a per-request nonce, assigns it to the conn (so the root layout can
+  # stamp it onto the inline Plausible `<script>`), and splices it into the
+  # `script-src` directive of the CSP header set by `put_secure_browser_headers`.
+  defp put_csp_nonce(conn, _opts) do
     nonce = 18 |> :crypto.strong_rand_bytes() |> Base.encode64()
-
-    csp =
-      "default-src 'self'; " <>
-        "img-src 'self' data:; " <>
-        "style-src 'self' 'unsafe-inline'; " <>
-        "script-src 'self' 'nonce-#{nonce}' https://plausible.io; " <>
-        "connect-src 'self' https://plausible.io"
 
     conn
     |> assign(:csp_nonce, nonce)
-    |> put_resp_header("content-security-policy", csp)
+    |> update_resp_header("content-security-policy", "", fn csp ->
+      String.replace(csp, "script-src ", "script-src 'nonce-#{nonce}' ")
+    end)
   end
 
   scope "/" do

--- a/lib/flick_web/router.ex
+++ b/lib/flick_web/router.ex
@@ -12,17 +12,8 @@ defmodule FlickWeb.Router do
     plug :put_root_layout, html: {FlickWeb.Layouts, :root}
     plug :protect_from_forgery
 
-    # Tailwind uses SVG data URLs for icons,
-    # so we need to allow them with `img-src`.
-    # https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
-    #
-    # To avoid web console issues with Phoenix Storybook we've added
-    # `style-src 'self' 'unsafe-inline'` which feels unfortunate and
-    # might be reconsidered.
-    plug :put_secure_browser_headers, %{
-      "content-security-policy" =>
-        "default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self' https://plausible.io; connect-src 'self' https://plausible.io"
-    }
+    plug :put_secure_browser_headers
+    plug :put_csp_headers
   end
 
   pipeline :admin do
@@ -31,6 +22,33 @@ defmodule FlickWeb.Router do
 
   pipeline :api do
     plug :accepts, ["json"]
+  end
+
+  # Sets our Content Security Policy header.
+  #
+  # We generate a per-request `nonce` so the small inline Plausible analytics
+  # `<script>` in the root layout is allowed without opening up `script-src` to
+  # `'unsafe-inline'`. The nonce is assigned to the conn so the layout can stamp
+  # it onto that script tag.
+  #
+  # `style-src` allows `'unsafe-inline'` to avoid web console issues with
+  # Phoenix Storybook, and `img-src` allows `data:` URLs because Tailwind uses
+  # SVG data URLs for icons.
+  #
+  # https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
+  defp put_csp_headers(conn, _opts) do
+    nonce = 18 |> :crypto.strong_rand_bytes() |> Base.encode64()
+
+    csp =
+      "default-src 'self'; " <>
+        "img-src 'self' data:; " <>
+        "style-src 'self' 'unsafe-inline'; " <>
+        "script-src 'self' 'nonce-#{nonce}' https://plausible.io; " <>
+        "connect-src 'self' https://plausible.io"
+
+    conn
+    |> assign(:csp_nonce, nonce)
+    |> put_resp_header("content-security-policy", csp)
   end
 
   scope "/" do

--- a/lib/flick_web/router.ex
+++ b/lib/flick_web/router.ex
@@ -5,6 +5,10 @@ defmodule FlickWeb.Router do
   import PhoenixStorybook.Router
   import Plug.BasicAuth
 
+  # Note: Sobelow's `Config.CSP` check only recognizes a CSP passed as a static
+  # map to `put_secure_browser_headers`. We set the header dynamically in
+  # `put_csp_headers` below (to inject a per-request nonce), so `Config.CSP` is
+  # ignored in `.sobelow-conf`.
   pipeline :browser do
     plug :accepts, ["html"]
     plug :fetch_session


### PR DESCRIPTION
## Problem

PR #181 switched to Plausible's new file-based script, which requires an inline `<script>` that calls `plausible.init()`. Our Content Security Policy (`script-src 'self' https://plausible.io`) had no `'unsafe-inline'` and no nonce, so the browser blocked the inline init and Plausible never initialized — no analytics were recorded.

## Fix

Allow exactly that one inline script via a per-request **nonce**, without opening `script-src` up to `'unsafe-inline'`:

- `put_secure_browser_headers` keeps the complete **static** CSP (unchanged from before, plus it remains the single source of truth).
- A small `put_csp_nonce` plug generates a per-request nonce, assigns it to the conn, and splices `'nonce-…'` into the `script-src` directive of that header.
- The root layout stamps the same nonce onto the inline analytics `<script>`.

A nonce (vs. a `'sha256-…'` hash) keeps Plausible's snippet in `<head>` in the recommended load order and is robust to future whitespace/formatting changes in the snippet.

### Why splice into the static header instead of building the CSP in the plug

Sobelow's `Config.CSP` check only recognizes a CSP passed as a static map to `put_secure_browser_headers`. Building the whole policy dynamically would force a global `Config.CSP` ignore, which would stop Sobelow from ever catching a genuinely missing CSP. Keeping the static policy and only enriching it with the nonce lets the check stay fully active and pass.

## Verification

- Ran the server and confirmed the CSP response header carries `script-src 'nonce-…' 'self' https://plausible.io` and the inline script's `nonce` attribute matches within the same response.
- `mix precommit` green (Credo clean, 108 tests pass); `mix sobelow --config` passes with **no CSP ignore**.